### PR TITLE
feat: introducing base metrics configuration mechanism

### DIFF
--- a/analyze_metrics.py
+++ b/analyze_metrics.py
@@ -1,0 +1,82 @@
+import re
+import requests
+from collections import defaultdict
+import os
+import sys
+
+# Function to parse OpenMetrics format and extract metric names, unique label keys, and unique label values
+def parse_openmetrics(metrics_text):
+    # Regex to match metric lines (metric name and labels)
+    metric_pattern = re.compile(r'^(?P<metric_name>[a-zA-Z_:][a-zA-Z0-9_:]+)(?P<labels>\{[^}]+\})?\s+(?P<value>\S+)')
+
+    metrics = defaultdict(lambda: defaultdict(set))
+
+    for line in metrics_text.splitlines():
+        # Skip comments and empty lines
+        if line.startswith('#') or not line.strip():
+            continue
+
+        # Match the metric line
+        match = metric_pattern.match(line)
+        if match:
+            metric_name = match.group('metric_name')
+            labels = match.group('labels')
+
+            # Parse labels if they exist
+            if labels:
+                # Extract label key-value pairs
+                label_pairs = re.findall(r'([a-zA-Z_][a-zA-Z0-9_]*)=["]([^"]*)["]', labels)
+                for key, value in label_pairs:
+                    metrics[metric_name][key].add(value)
+
+    return metrics
+
+# Fetch metrics from Prometheus Node Exporter
+def fetch_metrics_from_url(url):
+    response = requests.get(url)
+    if response.status_code == 200:
+        return response.text
+    else:
+        raise Exception(f"Failed to fetch metrics: {response.status_code}")
+
+# Read metrics from a local file
+def fetch_metrics_from_file(file_path):
+    if not os.path.isfile(file_path):
+        raise Exception(f"File not found: {file_path}")
+    with open(file_path, 'r') as file:
+        return file.read()
+
+# Main function
+def main():
+    if len(sys.argv) != 2:
+        print("Usage: python script.py <url_or_file>")
+        sys.exit(1)
+
+    input_arg = sys.argv[1]
+
+    try:
+        # Determine if the input is a URL or a file
+        if input_arg.startswith('http'):
+            metrics_text = fetch_metrics_from_url(input_arg)
+        else:
+            metrics_text = fetch_metrics_from_file(input_arg)
+
+        # Parse metrics
+        metrics = parse_openmetrics(metrics_text)
+
+        # Print results
+        for metric_name, label_data in metrics.items():
+            print(f"Metric: {metric_name}")
+            if label_data:
+                for label_key, label_values in label_data.items():
+                    print(f"  Label Key: {label_key}")
+                    print(f"    Unique Values: {', '.join(sorted(label_values))}")
+            else:
+                print("  No labels")
+            print()
+
+    except Exception as e:
+        print(f"Error: {e}")
+
+if __name__ == "__main__":
+    main()

--- a/analyze_metrics.py
+++ b/analyze_metrics.py
@@ -3,13 +3,14 @@ import requests
 from collections import defaultdict
 import os
 import sys
+import yaml
 
-# Function to parse OpenMetrics format and extract metric names, unique label keys, and unique label values
+# Function to parse OpenMetrics format and extract unique label combinations
 def parse_openmetrics(metrics_text):
     # Regex to match metric lines (metric name and labels)
     metric_pattern = re.compile(r'^(?P<metric_name>[a-zA-Z_:][a-zA-Z0-9_:]+)(?P<labels>\{[^}]+\})?\s+(?P<value>\S+)')
 
-    metrics = defaultdict(lambda: defaultdict(set))
+    metrics = defaultdict(set)
 
     for line in metrics_text.splitlines():
         # Skip comments and empty lines
@@ -22,14 +23,33 @@ def parse_openmetrics(metrics_text):
             metric_name = match.group('metric_name')
             labels = match.group('labels')
 
-            # Parse labels if they exist
+            # If labels exist, add them as a unique combination
             if labels:
-                # Extract label key-value pairs
+                # Extract label key-value pairs and sort them for consistency
                 label_pairs = re.findall(r'([a-zA-Z_][a-zA-Z0-9_]*)=["]([^"]*)["]', labels)
-                for key, value in label_pairs:
-                    metrics[metric_name][key].add(value)
+                sorted_labels = tuple(sorted((key, value) for key, value in label_pairs))
+                metrics[metric_name].add(sorted_labels)
+            else:
+                # No labels, add an empty tuple
+                metrics[metric_name].add(tuple())
 
     return metrics
+
+# Function to format label combinations as dictionaries
+def format_label_combinations(metrics):
+    formatted_metrics = {}
+    for metric_name, label_combinations in metrics.items():
+        if not label_combinations:
+            formatted_metrics[metric_name] = None
+            continue
+
+        # Convert each label combination to a dictionary
+        formatted_combinations = []
+        for combo in label_combinations:
+            formatted_combinations.append(dict(combo))
+        formatted_metrics[metric_name] = formatted_combinations
+
+    return formatted_metrics
 
 # Fetch metrics from Prometheus Node Exporter
 def fetch_metrics_from_url(url):
@@ -46,6 +66,27 @@ def fetch_metrics_from_file(file_path):
     with open(file_path, 'r') as file:
         return file.read()
 
+# Convert metrics data to YAML format
+def metrics_to_yaml(metrics):
+    yaml_data = {}
+    for metric_name, label_data in metrics.items():
+        yaml_data[metric_name] = {}
+        if label_data:
+            for label_key, label_values in label_data.items():
+                yaml_data[metric_name][label_key] = sorted(label_values)
+        else:
+            yaml_data[metric_name] = None
+    return yaml.dump(yaml_data, default_flow_style=False)
+
+# Function to print a summary of metrics and time-series to stderr
+def print_summary(metrics):
+    total_metrics = len(metrics)
+    total_time_series = sum(len(label_combinations) for label_combinations in metrics.values())
+
+    print("\n=== Summary ===", file=sys.stderr)
+    print(f"Total Metrics: {total_metrics}", file=sys.stderr)
+    print(f"Total Time-Series (Unique Label Combinations): {total_time_series}", file=sys.stderr)
+
 # Main function
 def main():
     if len(sys.argv) != 2:
@@ -61,19 +102,20 @@ def main():
         else:
             metrics_text = fetch_metrics_from_file(input_arg)
 
-        # Parse metrics
+        # Parse metrics and extract unique label combinations
         metrics = parse_openmetrics(metrics_text)
 
-        # Print results
-        for metric_name, label_data in metrics.items():
-            print(f"Metric: {metric_name}")
-            if label_data:
-                for label_key, label_values in label_data.items():
-                    print(f"  Label Key: {label_key}")
-                    print(f"    Unique Values: {', '.join(sorted(label_values))}")
-            else:
-                print("  No labels")
-            print()
+        # Format label combinations as dictionaries
+        formatted_metrics = format_label_combinations(metrics)
+
+        # Convert to YAML format
+        yaml_output = yaml.dump(formatted_metrics, default_flow_style=False)
+
+        # Print YAML output
+        print(yaml_output)
+
+        # Print summary to stderr
+        print_summary(metrics)
 
     except Exception as e:
         print(f"Error: {e}")

--- a/config.yaml
+++ b/config.yaml
@@ -1,192 +1,81 @@
-start: "2023-05-09T17:49:12+08:00"
-end: "2023-05-09T18:49:12+08:00"
+start: "2025-03-21T17:49:12+08:00"
+end: "2025-03-21T18:49:12+08:00"
 interval: 10 # 10s
-precision: 1000 # ms
-num-field: 10
+
+base: node_exporter.yaml
+
 tags:
   - name: hostname
-    type: STRING
     nullability: 0
-    dist:
-      type: constant_string
-      value: host-0
-  - name: region
     type: STRING
-    nullability: 0
     dist:
       type: weighted_preset
       preset:
-        - value: sg-central
+        - value: srv-app42
+          weight: 1
+        - value: host-db18
+          weight: 1
+        - value: web-proc7
+          weight: 1
+        - value: compute-53b
+          weight: 1
+        - value: node21c
+          weight: 1
+        - value: srv-data09
+          weight: 1
+        - value: db-worker5
+          weight: 1
+        - value: vm-prod83
+          weight: 1
+        - value: host-analytics4
+          weight: 1
+        - value: worker-batch2
+          weight: 1
+        - value: compute-vm11
+          weight: 1
+        - value: app-server16
+          weight: 1
+        - value: host-backend7
+          weight: 1
+        - value: node-cache22
+          weight: 1
+        - value: srv-queue08
+          weight: 1
+  - name: region
+    nullability: 0
+    type: STRING
+    dist:
+      type: weighted_preset
+      preset:
+        - value: ap-southeast-1
           weight: 1
         - value: us-east-1
           weight: 1
         - value: us-west-2
           weight: 1
-        - value: us-central-1
+        - value: eu-central-1
           weight: 1
-  - name: datacenter
-    type: STRING
+  - name: az
     nullability: 0
+    type: STRING
     dist:
       type: weighted_preset
       preset:
-        - value: dc-0
+        - value: az-0
           weight: 1
-        - value: dc-1
+        - value: az-1
           weight: 1
-  - name: rack
-    type: STRING
-    nullability: 0
-    dist:
-      type: weighted_preset
-      preset:
-        - value: "1"
+        - value: az-2
           weight: 1
-        - value: "2"
+        - value: az-3
           weight: 1
-        - value: "3"
+        - value: az-4
           weight: 1
-        - value: "4"
+        - value: az-5
           weight: 1
-  - name: os
-    type: STRING
-    nullability: 0
-    dist:
-      type: weighted_preset
-      preset:
-        - value: ubuntu-22.04
+        - value: az-6
           weight: 1
-        - value: ubuntu-20.04
-          weight: 0.5
-  - name: arch
-    type: STRING
-    nullability: 0
-    dist:
-      type: weighted_preset
-      preset:
-        - value: x86_64
-          weight: 1
-        - value: aarch64
-          weight: 1
-  - name: team
-    type: STRING
-    nullability: 0
-    dist:
-      type: weighted_preset
-      preset:
-        - value: HZ
-          weight: 15
-        - value: BJ
-          weight: 10
-        - value: SH
-          weight: 0
-        - value: GZ
-          weight: 2
-  - name: services
-    type: STRING
-    nullability: 0
-    dist:
-      type: weighted_preset
-      preset:
-        - value: etcd
-          weight: 1
-        - value: kafka
-          weight: 1
-        - value: frontend
-          weight: 10
-        - value: datanode
-          weight: 5
-        - value: metasrv
-          weight: 3
-  - name: services_version
-    type: STRING
-    nullability: 0
-    dist:
-      type: weighted_preset
-      preset:
-        - value: "1.0"
-          weight: 1
-        - value: "2.0"
-          weight: 1
-  - name: services_env
-    type: STRING
-    nullability: 0
-    dist:
-      type: weighted_preset
-      preset:
-        - value: offline
-          weight: 1
-        - value: test
-          weight: 2
-        - value: prod
+        - value: az-7
           weight: 1
 
 fields:
-  - name: cpu
-    type: FLOAT
-    nullability: 0
-    dist:
-      type: random
-      lower_bound: 0
-      upper_bound: 100
-  - name: mem
-    type: FLOAT
-    nullability: 0
-    dist:
-      type: normal
-      mean: 0.5
-      stddev: 0.1
-  - name: disk
-    type: FLOAT
-    nullability: 0
-    dist:
-      type: mono_inc
-      step: 11
-  - name: network
-    type: FLOAT
-    nullability: 0
-    dist:
-      type: normal
-      mean: 100
-      stddev: 2000
-  - name: io
-    type: FLOAT
-    nullability: 0
-    dist:
-      type: normal
-      mean: 0
-      stddev: 200
-  - name: cpu_temp
-    type: FLOAT
-    nullability: 0
-    dist:
-      type: uniform
-      lower_bound: 0
-      upper_bound: 100
-  - name: mem_temp
-    type: FLOAT
-    nullability: 0
-    dist:
-      type: noise
-      max_fluctuation: 30
-  - name: disk_temp
-    type: FLOAT
-    nullability: 0
-    dist:
-      type: normal
-      mean: 0.5
-      stddev: 0.1
-  - name: network_temp
-    type: FLOAT
-    nullability: 0
-    dist:
-      type: periodic
-      period: 100
-      amplitude: 204800
-      bias: 1024
-  - name: io_temp
-    type: FLOAT
-    nullability: 0
-    dist:
-      type: constant_float
-      value: 10.1

--- a/config.yaml
+++ b/config.yaml
@@ -41,6 +41,26 @@ tags:
           weight: 1
         - value: srv-queue08
           weight: 1
+        - value: srv-frontend3
+          weight: 1
+        - value:  db-shard17
+          weight: 1
+        - value: vm-staging42
+          weight: 1
+        - value: compute-web19
+          weight: 1
+        - value: node-api06
+          weight: 1
+        - value: srv-backup11
+          weight: 1
+        - value: host-processing4
+          weight: 1
+        - value: worker-job15
+          weight: 1
+        - value: app-gateway8
+          weight: 1
+        - value: vm-storage24
+          weight: 1
   - name: region
     nullability: 0
     type: STRING

--- a/distribution.py
+++ b/distribution.py
@@ -22,7 +22,8 @@ class Distribution(ABC):
     def generator(self):
         pass
 
-    def from_config(config: dict):
+    @classmethod
+    def from_config(_cls, config: dict):
         """
         Selects the appropriate distribution class based on configuration and returns its instance.
 
@@ -245,7 +246,8 @@ class Weight:
         self.value = value
         self.weight = weight
 
-    def from_config(config: dict):
+    @classmethod
+    def from_config(_cls, config: dict):
         return Weight(config["value"], config["weight"])
 
 
@@ -260,7 +262,8 @@ class WeightedPreset(Distribution):
     def all(self) -> list:
         return [p.value for p in self.presets]
 
-    def from_config(config: list):
+    @classmethod
+    def from_config(_cls, config: list):
         return WeightedPreset([Weight.from_config(p) for p in config])
 
     def generator(self):

--- a/main.py
+++ b/main.py
@@ -1,5 +1,5 @@
 import argparse
-import csv
+import copy
 import yaml
 import itertools
 from functools import reduce
@@ -12,6 +12,7 @@ from proto.remote_pb2 import WriteRequest
 from proto.types_pb2 import TimeSeries, Label, Sample
 
 from col import Column
+from distribution import Random
 
 # Parse command line arguments and return the parsed result
 def arg_parser():
@@ -24,7 +25,6 @@ def arg_parser():
     parser = argparse.ArgumentParser(
         prog="tsdg", description="Time-Series Data Generator"
     )
-    parser.add_argument("-o", "--csvout", help="generate csv output file")
     parser.add_argument("--promout", help="generate remote write protobuf data")
     parser.add_argument("-c", "--config", default="./config.yaml", help="config file")
     return parser.parse_args()
@@ -47,54 +47,15 @@ def tag_set_permutation(tags: list):
     permutation = [dict(zip(keys, v)) for v in itertools.product(*values)]
     return permutation
 
-# Generate time-series data based on configuration
-def generate_csv_data(
-    start: int,
-    end: int,
-    interval: int,
-    precision: int,
-    tags: list,
-    fields: list,
-    csv_out: str,
-):
-    """
-    Generates time-series data based on the provided configuration and writes it to a CSV file.
-
-    Args:
-        start (int): Start time in UNIX timestamp.
-        end (int): End time in UNIX timestamp.
-        interval (int): Time interval between data points.
-        precision (int): Precision of the timestamp.
-        tags (list): List of tag definitions.
-        fields (list): List of field definitions.
-        csv_out (str): Output file for the generated CSV file.
-    """
-    with open(csv_out, "w", newline="") as output:
-        writer = csv.writer(output, delimiter=",")
-        # write header
-        header = ["ts"] + [t.name for t in tags] + [f.name for f in fields]
-        writer.writerow(header)
-        tags_permutation = tag_set_permutation(tags)
-        series_generator = [
-            [series, dict([[field.name, field.dist.generator()] for field in fields])]
-            for series in tags_permutation
-        ]
-        # write rows
-        for ts in trange(start, end, interval):
-            for series in series_generator:
-                timestamp = ts * precision
-                tag_array = [v for v in series[0].values()]
-                field_array = [next(v) for v in series[1].values()]
-                writer.writerow([timestamp] + tag_array + field_array)
 
 # Generate time-series data based on configuration
 def generate_prom_data(
     start: int,
     end: int,
     interval: int,
-    precision: int,
+    base_metrics: dict,
     tags: list,
-    fields: list,
+    fields: dict,
     prom_out: str,
 ):
     """
@@ -104,11 +65,14 @@ def generate_prom_data(
         end (int): End time in UNIX timestamp.
         interval (int): Time interval between data points.
         precision (int): Precision of the timestamp.
-        tags (list): List of tag definitions.
-        fields (list): List of field definitions.
+        base_metrics (list): The base prometheus metrics to generate from
+        tags (list): Additional tags definitions.
+        fields (dict): dict of field definitions.
         prom_out (str): Output file for the generated CSV file.
     """
     BATCH_SIZE = 10000000
+    PRECISION = 1000
+
     accum_size = 0
     file_index = 0
     total_counter = 0
@@ -116,10 +80,6 @@ def generate_prom_data(
     time_slice = 5 * 60 ## 5 mins
 
     tags_permutation = tag_set_permutation(tags)
-    series_generator = [
-        [series, dict([[field.name, field.dist.generator()] for field in fields])]
-        for series in tags_permutation
-    ]
 
     ## open writer from file index 0
     writer = open(prom_file(prom_out, file_index), 'wb')
@@ -128,42 +88,55 @@ def generate_prom_data(
     for slice_start in trange(start, end, time_slice):
 
         ## for each tag combination
-        for series in series_generator:
+        for series in tags_permutation:
             labels = {}
 
             ## assign tags
-            for (label_name, label_value) in series[0].items():
+            for (label_name, label_value) in series.items():
                 labels[label_name] = label_value
 
             ## for each metric
-            for (field, field_gen) in series[1].items():
+            for (field, metrics_base_labels) in base_metrics.items():
                 ## set metric name
                 labels['__name__'] = field
-                ## reset sample array
-                samples = []
 
-                ## generate full time series
-                for ts in range(slice_start, slice_start+time_slice, interval):
-                    timestamp = ts * precision
-                    value = next(field_gen)
-                    samples.append((timestamp, value))
-                    accum_size += 1
+                for base_labels in metrics_base_labels:
+                    local_labels = copy.copy(labels)
+                    local_labels.update(base_labels)
 
-                time_series.append(build_timeseries(labels, samples))
+                    ## field_gen: if specified via
+                    ## FIXME: this should be generated per time-series
+                    field_def = fields.get(field)
+                    if field_def is not None:
+                        field_gen = field_def.dist.generator()
+                    else:
+                        field_gen = Random(0, 100).generator()
 
-                ## flush to file and start a new file
-                if accum_size >= BATCH_SIZE:
-                    write_request = build_remote_write_message(time_series)
-                    writer.write(write_request)
-                    writer.close()
+                    ## reset sample array
+                    samples = []
 
-                    ## open new file
-                    file_index += 1
-                    writer = open(prom_file(prom_out, file_index), 'wb')
-                    ## reset counters
-                    total_counter += accum_size
-                    accum_size = 0
-                    time_series = []
+                    ## generate full time series
+                    for ts in range(slice_start, slice_start+time_slice, interval):
+                        timestamp = ts * PRECISION
+                        value = next(field_gen)
+                        samples.append((timestamp, value))
+                        accum_size += 1
+
+                    time_series.append(build_timeseries(local_labels, samples))
+
+                    ## flush to file and start a new file
+                    if accum_size >= BATCH_SIZE:
+                        write_request = build_remote_write_message(time_series)
+                        writer.write(write_request)
+                        writer.close()
+
+                        ## open new file
+                        file_index += 1
+                        writer = open(prom_file(prom_out, file_index), 'wb')
+                        ## reset counters
+                        total_counter += accum_size
+                        accum_size = 0
+                        time_series = []
 
     write_request = build_remote_write_message(time_series)
     writer.write(write_request)
@@ -235,6 +208,9 @@ def parse_col_defs(fields: list) -> list:
     Returns:
         list: A list of Column objects.
     """
+    if not fields:
+        return []
+
     return [Column.from_config(f) for f in fields]
 
 # Main function
@@ -251,28 +227,22 @@ def main():
     start = int(parse_time(config["start"]))
     end = int(parse_time(config["end"]))
     interval = int(config["interval"])
-    precision = int(config["precision"])
 
+    base_metrics = load_yaml(config['base'])
+    print(f"Loaded base metrics: {len(base_metrics)}")
     tags = parse_col_defs(config["tags"])
-    fields = parse_col_defs(config["fields"])
 
-    if args.csvout is not None:
-        generate_csv_data(
-            start=start,
-            end=end,
-            interval=interval,
-            precision=precision,
-            tags=tags,
-            fields=fields,
-            csv_out=args.csvout,
-        )
+    field_list = parse_col_defs(config["fields"])
+    fields = {}
+    for f in field_list:
+        fields[f['name']] = f
 
     if args.promout is not None:
         generate_prom_data(
             start=start,
             end=end,
             interval=interval,
-            precision=precision,
+            base_metrics=base_metrics,
             tags=tags,
             fields=fields,
             prom_out=args.promout,

--- a/node_exporter.yaml
+++ b/node_exporter.yaml
@@ -1,0 +1,2119 @@
+go_gc_duration_seconds:
+- quantile: '0.5'
+- quantile: '0.75'
+- quantile: '1'
+- quantile: '0.25'
+- quantile: '0'
+go_gc_duration_seconds_count:
+- {}
+go_gc_duration_seconds_sum:
+- {}
+go_goroutines:
+- {}
+go_info:
+- version: go1.21.4
+go_memstats_alloc_bytes:
+- {}
+go_memstats_alloc_bytes_total:
+- {}
+go_memstats_buck_hash_sys_bytes:
+- {}
+go_memstats_frees_total:
+- {}
+go_memstats_gc_sys_bytes:
+- {}
+go_memstats_heap_alloc_bytes:
+- {}
+go_memstats_heap_idle_bytes:
+- {}
+go_memstats_heap_inuse_bytes:
+- {}
+go_memstats_heap_objects:
+- {}
+go_memstats_heap_released_bytes:
+- {}
+go_memstats_heap_sys_bytes:
+- {}
+go_memstats_last_gc_time_seconds:
+- {}
+go_memstats_lookups_total:
+- {}
+go_memstats_mallocs_total:
+- {}
+go_memstats_mcache_inuse_bytes:
+- {}
+go_memstats_mcache_sys_bytes:
+- {}
+go_memstats_mspan_inuse_bytes:
+- {}
+go_memstats_mspan_sys_bytes:
+- {}
+go_memstats_next_gc_bytes:
+- {}
+go_memstats_other_sys_bytes:
+- {}
+go_memstats_stack_inuse_bytes:
+- {}
+go_memstats_stack_sys_bytes:
+- {}
+go_memstats_sys_bytes:
+- {}
+go_threads:
+- {}
+node_boot_time_seconds:
+- {}
+node_context_switches_total:
+- {}
+node_cooling_device_cur_state:
+- name: '11'
+  type: Processor
+- name: '3'
+  type: Processor
+- name: '4'
+  type: Processor
+- name: '14'
+  type: Processor
+- name: '7'
+  type: Processor
+- name: '13'
+  type: Processor
+- name: '0'
+  type: Processor
+- name: '2'
+  type: Processor
+- name: '15'
+  type: Processor
+- name: '16'
+  type: LCD
+- name: '9'
+  type: Processor
+- name: '1'
+  type: Processor
+- name: '12'
+  type: Processor
+- name: '5'
+  type: Processor
+- name: '6'
+  type: Processor
+- name: '10'
+  type: Processor
+- name: '8'
+  type: Processor
+node_cooling_device_max_state:
+- name: '11'
+  type: Processor
+- name: '3'
+  type: Processor
+- name: '4'
+  type: Processor
+- name: '14'
+  type: Processor
+- name: '7'
+  type: Processor
+- name: '13'
+  type: Processor
+- name: '0'
+  type: Processor
+- name: '2'
+  type: Processor
+- name: '15'
+  type: Processor
+- name: '16'
+  type: LCD
+- name: '9'
+  type: Processor
+- name: '1'
+  type: Processor
+- name: '12'
+  type: Processor
+- name: '5'
+  type: Processor
+- name: '6'
+  type: Processor
+- name: '10'
+  type: Processor
+- name: '8'
+  type: Processor
+node_cpu_frequency_max_hertz:
+- cpu: '4'
+- cpu: '8'
+- cpu: '11'
+- cpu: '1'
+- cpu: '2'
+- cpu: '13'
+- cpu: '12'
+- cpu: '15'
+- cpu: '6'
+- cpu: '9'
+- cpu: '14'
+- cpu: '0'
+- cpu: '10'
+- cpu: '5'
+- cpu: '3'
+- cpu: '7'
+node_cpu_frequency_min_hertz:
+- cpu: '4'
+- cpu: '8'
+- cpu: '11'
+- cpu: '1'
+- cpu: '2'
+- cpu: '13'
+- cpu: '12'
+- cpu: '15'
+- cpu: '6'
+- cpu: '9'
+- cpu: '14'
+- cpu: '0'
+- cpu: '10'
+- cpu: '5'
+- cpu: '3'
+- cpu: '7'
+node_cpu_guest_seconds_total:
+- cpu: '7'
+  mode: nice
+- cpu: '1'
+  mode: nice
+- cpu: '15'
+  mode: user
+- cpu: '3'
+  mode: nice
+- cpu: '10'
+  mode: user
+- cpu: '6'
+  mode: nice
+- cpu: '8'
+  mode: user
+- cpu: '2'
+  mode: nice
+- cpu: '11'
+  mode: nice
+- cpu: '12'
+  mode: user
+- cpu: '4'
+  mode: user
+- cpu: '5'
+  mode: user
+- cpu: '14'
+  mode: user
+- cpu: '13'
+  mode: user
+- cpu: '9'
+  mode: user
+- cpu: '0'
+  mode: user
+- cpu: '15'
+  mode: nice
+- cpu: '10'
+  mode: nice
+- cpu: '12'
+  mode: nice
+- cpu: '1'
+  mode: user
+- cpu: '8'
+  mode: nice
+- cpu: '7'
+  mode: user
+- cpu: '4'
+  mode: nice
+- cpu: '3'
+  mode: user
+- cpu: '5'
+  mode: nice
+- cpu: '6'
+  mode: user
+- cpu: '14'
+  mode: nice
+- cpu: '2'
+  mode: user
+- cpu: '13'
+  mode: nice
+- cpu: '9'
+  mode: nice
+- cpu: '0'
+  mode: nice
+- cpu: '11'
+  mode: user
+node_cpu_scaling_frequency_hertz:
+- cpu: '4'
+- cpu: '8'
+- cpu: '11'
+- cpu: '1'
+- cpu: '2'
+- cpu: '13'
+- cpu: '12'
+- cpu: '15'
+- cpu: '6'
+- cpu: '9'
+- cpu: '14'
+- cpu: '0'
+- cpu: '10'
+- cpu: '5'
+- cpu: '3'
+- cpu: '7'
+node_cpu_scaling_frequency_max_hertz:
+- cpu: '4'
+- cpu: '8'
+- cpu: '11'
+- cpu: '1'
+- cpu: '2'
+- cpu: '13'
+- cpu: '12'
+- cpu: '15'
+- cpu: '6'
+- cpu: '9'
+- cpu: '14'
+- cpu: '0'
+- cpu: '10'
+- cpu: '5'
+- cpu: '3'
+- cpu: '7'
+node_cpu_scaling_frequency_min_hertz:
+- cpu: '4'
+- cpu: '8'
+- cpu: '11'
+- cpu: '1'
+- cpu: '2'
+- cpu: '13'
+- cpu: '12'
+- cpu: '15'
+- cpu: '6'
+- cpu: '9'
+- cpu: '14'
+- cpu: '0'
+- cpu: '10'
+- cpu: '5'
+- cpu: '3'
+- cpu: '7'
+node_cpu_scaling_governor:
+- cpu: '1'
+  governor: powersave
+- cpu: '6'
+  governor: performance
+- cpu: '10'
+  governor: userspace
+- cpu: '11'
+  governor: performance
+- cpu: '6'
+  governor: powersave
+- cpu: '8'
+  governor: ondemand
+- cpu: '4'
+  governor: userspace
+- cpu: '11'
+  governor: powersave
+- cpu: '5'
+  governor: userspace
+- cpu: '15'
+  governor: performance
+- cpu: '14'
+  governor: userspace
+- cpu: '13'
+  governor: userspace
+- cpu: '0'
+  governor: ondemand
+- cpu: '15'
+  governor: powersave
+- cpu: '1'
+  governor: schedutil
+- cpu: '7'
+  governor: ondemand
+- cpu: '1'
+  governor: conservative
+- cpu: '3'
+  governor: ondemand
+- cpu: '6'
+  governor: schedutil
+- cpu: '9'
+  governor: performance
+- cpu: '2'
+  governor: userspace
+- cpu: '11'
+  governor: ondemand
+- cpu: '6'
+  governor: conservative
+- cpu: '15'
+  governor: schedutil
+- cpu: '10'
+  governor: schedutil
+- cpu: '15'
+  governor: conservative
+- cpu: '8'
+  governor: userspace
+- cpu: '10'
+  governor: conservative
+- cpu: '5'
+  governor: schedutil
+- cpu: '12'
+  governor: ondemand
+- cpu: '14'
+  governor: schedutil
+- cpu: '4'
+  governor: conservative
+- cpu: '9'
+  governor: schedutil
+- cpu: '5'
+  governor: conservative
+- cpu: '0'
+  governor: userspace
+- cpu: '14'
+  governor: conservative
+- cpu: '10'
+  governor: performance
+- cpu: '9'
+  governor: conservative
+- cpu: '4'
+  governor: performance
+- cpu: '10'
+  governor: powersave
+- cpu: '1'
+  governor: ondemand
+- cpu: '7'
+  governor: userspace
+- cpu: '3'
+  governor: userspace
+- cpu: '4'
+  governor: powersave
+- cpu: '5'
+  governor: performance
+- cpu: '14'
+  governor: performance
+- cpu: '13'
+  governor: performance
+- cpu: '5'
+  governor: powersave
+- cpu: '6'
+  governor: ondemand
+- cpu: '14'
+  governor: powersave
+- cpu: '13'
+  governor: powersave
+- cpu: '2'
+  governor: conservative
+- cpu: '9'
+  governor: powersave
+- cpu: '15'
+  governor: ondemand
+- cpu: '2'
+  governor: performance
+- cpu: '10'
+  governor: ondemand
+- cpu: '4'
+  governor: schedutil
+- cpu: '12'
+  governor: userspace
+- cpu: '2'
+  governor: powersave
+- cpu: '0'
+  governor: schedutil
+- cpu: '13'
+  governor: schedutil
+- cpu: '9'
+  governor: ondemand
+- cpu: '0'
+  governor: conservative
+- cpu: '7'
+  governor: schedutil
+- cpu: '13'
+  governor: conservative
+- cpu: '8'
+  governor: performance
+- cpu: '1'
+  governor: userspace
+- cpu: '8'
+  governor: powersave
+- cpu: '7'
+  governor: conservative
+- cpu: '2'
+  governor: schedutil
+- cpu: '0'
+  governor: performance
+- cpu: '6'
+  governor: userspace
+- cpu: '0'
+  governor: powersave
+- cpu: '11'
+  governor: userspace
+- cpu: '7'
+  governor: performance
+- cpu: '3'
+  governor: performance
+- cpu: '15'
+  governor: userspace
+- cpu: '7'
+  governor: powersave
+- cpu: '3'
+  governor: powersave
+- cpu: '12'
+  governor: schedutil
+- cpu: '8'
+  governor: schedutil
+- cpu: '12'
+  governor: conservative
+- cpu: '4'
+  governor: ondemand
+- cpu: '8'
+  governor: conservative
+- cpu: '5'
+  governor: ondemand
+- cpu: '9'
+  governor: userspace
+- cpu: '14'
+  governor: ondemand
+- cpu: '13'
+  governor: ondemand
+- cpu: '12'
+  governor: performance
+- cpu: '3'
+  governor: schedutil
+- cpu: '12'
+  governor: powersave
+- cpu: '11'
+  governor: schedutil
+- cpu: '3'
+  governor: conservative
+- cpu: '2'
+  governor: ondemand
+- cpu: '11'
+  governor: conservative
+- cpu: '1'
+  governor: performance
+node_cpu_seconds_total:
+- cpu: '15'
+  mode: iowait
+- cpu: '5'
+  mode: irq
+- cpu: '1'
+  mode: nice
+- cpu: '10'
+  mode: system
+- cpu: '14'
+  mode: irq
+- cpu: '13'
+  mode: irq
+- cpu: '4'
+  mode: system
+- cpu: '0'
+  mode: steal
+- cpu: '13'
+  mode: steal
+- cpu: '2'
+  mode: softirq
+- cpu: '6'
+  mode: nice
+- cpu: '5'
+  mode: system
+- cpu: '12'
+  mode: user
+- cpu: '14'
+  mode: system
+- cpu: '13'
+  mode: system
+- cpu: '7'
+  mode: steal
+- cpu: '3'
+  mode: steal
+- cpu: '9'
+  mode: iowait
+- cpu: '2'
+  mode: irq
+- cpu: '15'
+  mode: nice
+- cpu: '6'
+  mode: idle
+- cpu: '10'
+  mode: nice
+- cpu: '8'
+  mode: softirq
+- cpu: '1'
+  mode: user
+- cpu: '2'
+  mode: system
+- cpu: '5'
+  mode: nice
+- cpu: '6'
+  mode: user
+- cpu: '0'
+  mode: softirq
+- cpu: '8'
+  mode: irq
+- cpu: '9'
+  mode: nice
+- cpu: '10'
+  mode: idle
+- cpu: '11'
+  mode: user
+- cpu: '12'
+  mode: steal
+- cpu: '4'
+  mode: idle
+- cpu: '7'
+  mode: softirq
+- cpu: '3'
+  mode: softirq
+- cpu: '5'
+  mode: idle
+- cpu: '0'
+  mode: irq
+- cpu: '8'
+  mode: system
+- cpu: '14'
+  mode: idle
+- cpu: '10'
+  mode: iowait
+- cpu: '15'
+  mode: user
+- cpu: '4'
+  mode: iowait
+- cpu: '9'
+  mode: idle
+- cpu: '7'
+  mode: irq
+- cpu: '1'
+  mode: steal
+- cpu: '0'
+  mode: system
+- cpu: '3'
+  mode: irq
+- cpu: '5'
+  mode: iowait
+- cpu: '14'
+  mode: iowait
+- cpu: '13'
+  mode: iowait
+- cpu: '9'
+  mode: user
+- cpu: '2'
+  mode: idle
+- cpu: '7'
+  mode: system
+- cpu: '3'
+  mode: system
+- cpu: '11'
+  mode: steal
+- cpu: '12'
+  mode: softirq
+- cpu: '4'
+  mode: nice
+- cpu: '2'
+  mode: iowait
+- cpu: '15'
+  mode: steal
+- cpu: '14'
+  mode: nice
+- cpu: '13'
+  mode: nice
+- cpu: '12'
+  mode: irq
+- cpu: '8'
+  mode: idle
+- cpu: '1'
+  mode: softirq
+- cpu: '7'
+  mode: nice
+- cpu: '12'
+  mode: system
+- cpu: '0'
+  mode: idle
+- cpu: '8'
+  mode: iowait
+- cpu: '13'
+  mode: idle
+- cpu: '6'
+  mode: softirq
+- cpu: '10'
+  mode: user
+- cpu: '1'
+  mode: irq
+- cpu: '2'
+  mode: nice
+- cpu: '11'
+  mode: softirq
+- cpu: '4'
+  mode: user
+- cpu: '7'
+  mode: idle
+- cpu: '3'
+  mode: idle
+- cpu: '0'
+  mode: iowait
+- cpu: '5'
+  mode: user
+- cpu: '14'
+  mode: user
+- cpu: '6'
+  mode: irq
+- cpu: '13'
+  mode: user
+- cpu: '15'
+  mode: softirq
+- cpu: '1'
+  mode: system
+- cpu: '11'
+  mode: irq
+- cpu: '6'
+  mode: steal
+- cpu: '7'
+  mode: iowait
+- cpu: '3'
+  mode: iowait
+- cpu: '12'
+  mode: nice
+- cpu: '8'
+  mode: nice
+- cpu: '6'
+  mode: system
+- cpu: '15'
+  mode: irq
+- cpu: '11'
+  mode: iowait
+- cpu: '11'
+  mode: system
+- cpu: '9'
+  mode: softirq
+- cpu: '2'
+  mode: user
+- cpu: '0'
+  mode: nice
+- cpu: '10'
+  mode: steal
+- cpu: '12'
+  mode: idle
+- cpu: '15'
+  mode: system
+- cpu: '4'
+  mode: steal
+- cpu: '5'
+  mode: steal
+- cpu: '9'
+  mode: irq
+- cpu: '14'
+  mode: steal
+- cpu: '3'
+  mode: nice
+- cpu: '12'
+  mode: iowait
+- cpu: '9'
+  mode: steal
+- cpu: '8'
+  mode: user
+- cpu: '11'
+  mode: nice
+- cpu: '1'
+  mode: idle
+- cpu: '9'
+  mode: system
+- cpu: '0'
+  mode: user
+- cpu: '2'
+  mode: steal
+- cpu: '1'
+  mode: iowait
+- cpu: '11'
+  mode: idle
+- cpu: '10'
+  mode: softirq
+- cpu: '4'
+  mode: softirq
+- cpu: '7'
+  mode: user
+- cpu: '3'
+  mode: user
+- cpu: '6'
+  mode: iowait
+- cpu: '15'
+  mode: idle
+- cpu: '5'
+  mode: softirq
+- cpu: '14'
+  mode: softirq
+- cpu: '13'
+  mode: softirq
+- cpu: '10'
+  mode: irq
+- cpu: '4'
+  mode: irq
+- cpu: '8'
+  mode: steal
+node_disk_discard_time_seconds_total:
+- device: nvme0n1
+node_disk_discarded_sectors_total:
+- device: nvme0n1
+node_disk_discards_completed_total:
+- device: nvme0n1
+node_disk_discards_merged_total:
+- device: nvme0n1
+node_disk_flush_requests_time_seconds_total:
+- device: nvme0n1
+node_disk_flush_requests_total:
+- device: nvme0n1
+node_disk_info:
+- device: nvme0n1
+  major: '259'
+  minor: '0'
+  model: ''
+  path: ''
+  revision: ''
+  serial: ''
+  wwn: ''
+node_disk_io_now:
+- device: nvme0n1
+node_disk_io_time_seconds_total:
+- device: nvme0n1
+node_disk_io_time_weighted_seconds_total:
+- device: nvme0n1
+node_disk_read_bytes_total:
+- device: nvme0n1
+node_disk_read_time_seconds_total:
+- device: nvme0n1
+node_disk_reads_completed_total:
+- device: nvme0n1
+node_disk_reads_merged_total:
+- device: nvme0n1
+node_disk_write_time_seconds_total:
+- device: nvme0n1
+node_disk_writes_completed_total:
+- device: nvme0n1
+node_disk_writes_merged_total:
+- device: nvme0n1
+node_disk_written_bytes_total:
+- device: nvme0n1
+node_dmi_info:
+- bios_date: 04/26/2023
+  bios_release: '5.24'
+  bios_vendor: American Megatrends International, LLC.
+  bios_version: '113'
+  board_asset_tag: Default string
+  board_name: SER
+  board_vendor: AZW
+  board_version: Version 1.0
+  chassis_asset_tag: Default string
+  chassis_vendor: Default string
+  chassis_version: Default string
+  product_family: SE
+  product_name: SER
+  product_sku: Default SKU
+  product_version: Version 1.0
+  system_vendor: AZW
+node_entropy_available_bits:
+- {}
+node_entropy_pool_size_bits:
+- {}
+node_exporter_build_info:
+- branch: HEAD
+  goarch: amd64
+  goos: linux
+  goversion: go1.21.4
+  revision: 7333465abf9efba81876303bb57e6fadb946041b
+  tags: netgo osusergo static_build
+  version: 1.7.0
+node_filefd_allocated:
+- {}
+node_filefd_maximum:
+- {}
+node_filesystem_avail_bytes:
+- device: tmpfs
+  fstype: tmpfs
+  mountpoint: /run/user/1004
+- device: /dev/nvme0n1p2
+  fstype: ext4
+  mountpoint: /
+- device: tmpfs
+  fstype: tmpfs
+  mountpoint: /run
+- device: /dev/nvme0n1p1
+  fstype: vfat
+  mountpoint: /boot/efi
+- device: tmpfs
+  fstype: tmpfs
+  mountpoint: /run/user/1000
+- device: tmpfs
+  fstype: tmpfs
+  mountpoint: /run/lock
+node_filesystem_device_error:
+- device: tmpfs
+  fstype: tmpfs
+  mountpoint: /run/user/1004
+- device: /dev/nvme0n1p2
+  fstype: ext4
+  mountpoint: /
+- device: tmpfs
+  fstype: tmpfs
+  mountpoint: /run
+- device: /dev/nvme0n1p1
+  fstype: vfat
+  mountpoint: /boot/efi
+- device: tmpfs
+  fstype: tmpfs
+  mountpoint: /run/user/1000
+- device: tmpfs
+  fstype: tmpfs
+  mountpoint: /run/lock
+node_filesystem_files:
+- device: tmpfs
+  fstype: tmpfs
+  mountpoint: /run/user/1004
+- device: /dev/nvme0n1p2
+  fstype: ext4
+  mountpoint: /
+- device: tmpfs
+  fstype: tmpfs
+  mountpoint: /run
+- device: /dev/nvme0n1p1
+  fstype: vfat
+  mountpoint: /boot/efi
+- device: tmpfs
+  fstype: tmpfs
+  mountpoint: /run/user/1000
+- device: tmpfs
+  fstype: tmpfs
+  mountpoint: /run/lock
+node_filesystem_files_free:
+- device: tmpfs
+  fstype: tmpfs
+  mountpoint: /run/user/1004
+- device: /dev/nvme0n1p2
+  fstype: ext4
+  mountpoint: /
+- device: tmpfs
+  fstype: tmpfs
+  mountpoint: /run
+- device: /dev/nvme0n1p1
+  fstype: vfat
+  mountpoint: /boot/efi
+- device: tmpfs
+  fstype: tmpfs
+  mountpoint: /run/user/1000
+- device: tmpfs
+  fstype: tmpfs
+  mountpoint: /run/lock
+node_filesystem_free_bytes:
+- device: tmpfs
+  fstype: tmpfs
+  mountpoint: /run/user/1004
+- device: /dev/nvme0n1p2
+  fstype: ext4
+  mountpoint: /
+- device: tmpfs
+  fstype: tmpfs
+  mountpoint: /run
+- device: /dev/nvme0n1p1
+  fstype: vfat
+  mountpoint: /boot/efi
+- device: tmpfs
+  fstype: tmpfs
+  mountpoint: /run/user/1000
+- device: tmpfs
+  fstype: tmpfs
+  mountpoint: /run/lock
+node_filesystem_readonly:
+- device: tmpfs
+  fstype: tmpfs
+  mountpoint: /run/user/1004
+- device: /dev/nvme0n1p2
+  fstype: ext4
+  mountpoint: /
+- device: tmpfs
+  fstype: tmpfs
+  mountpoint: /run
+- device: /dev/nvme0n1p1
+  fstype: vfat
+  mountpoint: /boot/efi
+- device: tmpfs
+  fstype: tmpfs
+  mountpoint: /run/user/1000
+- device: tmpfs
+  fstype: tmpfs
+  mountpoint: /run/lock
+node_filesystem_size_bytes:
+- device: tmpfs
+  fstype: tmpfs
+  mountpoint: /run/user/1004
+- device: /dev/nvme0n1p2
+  fstype: ext4
+  mountpoint: /
+- device: tmpfs
+  fstype: tmpfs
+  mountpoint: /run
+- device: /dev/nvme0n1p1
+  fstype: vfat
+  mountpoint: /boot/efi
+- device: tmpfs
+  fstype: tmpfs
+  mountpoint: /run/user/1000
+- device: tmpfs
+  fstype: tmpfs
+  mountpoint: /run/lock
+node_forks_total:
+- {}
+node_hwmon_chip_names:
+- chip: nvme_nvme0
+  chip_name: nvme
+- chip: thermal_thermal_zone0
+  chip_name: acpitz
+- chip: 0000:00:08_1_0000:74:00_0
+  chip_name: amdgpu
+- chip: pci0000:00_0000:00:18_3
+  chip_name: k10temp
+- chip: thermal_thermal_zone1
+  chip_name: iwlwifi_1
+node_hwmon_in_volts:
+- chip: 0000:00:08_1_0000:74:00_0
+  sensor: in0
+- chip: 0000:00:08_1_0000:74:00_0
+  sensor: in1
+node_hwmon_power_average_watt:
+- chip: 0000:00:08_1_0000:74:00_0
+  sensor: power1
+node_hwmon_sensor_label:
+- chip: pci0000:00_0000:00:18_3
+  label: Tctl
+  sensor: temp1
+- chip: 0000:00:08_1_0000:74:00_0
+  label: vddgfx
+  sensor: in0
+- chip: nvme_nvme0
+  label: Composite
+  sensor: temp1
+- chip: 0000:00:08_1_0000:74:00_0
+  label: slowPPT
+  sensor: power1
+- chip: 0000:00:08_1_0000:74:00_0
+  label: vddnb
+  sensor: in1
+- chip: nvme_nvme0
+  label: Sensor 1
+  sensor: temp2
+- chip: 0000:00:08_1_0000:74:00_0
+  label: edge
+  sensor: temp1
+- chip: nvme_nvme0
+  label: Sensor 2
+  sensor: temp3
+node_hwmon_temp_alarm:
+- chip: nvme_nvme0
+  sensor: temp1
+node_hwmon_temp_celsius:
+- chip: thermal_thermal_zone0
+  sensor: temp0
+- chip: nvme_nvme0
+  sensor: temp3
+- chip: pci0000:00_0000:00:18_3
+  sensor: temp1
+- chip: nvme_nvme0
+  sensor: temp1
+- chip: nvme_nvme0
+  sensor: temp2
+- chip: thermal_thermal_zone0
+  sensor: temp1
+- chip: 0000:00:08_1_0000:74:00_0
+  sensor: temp1
+node_hwmon_temp_crit_celsius:
+- chip: thermal_thermal_zone0
+  sensor: temp1
+- chip: nvme_nvme0
+  sensor: temp1
+node_hwmon_temp_max_celsius:
+- chip: nvme_nvme0
+  sensor: temp3
+- chip: nvme_nvme0
+  sensor: temp2
+- chip: nvme_nvme0
+  sensor: temp1
+node_hwmon_temp_min_celsius:
+- chip: nvme_nvme0
+  sensor: temp3
+- chip: nvme_nvme0
+  sensor: temp2
+- chip: nvme_nvme0
+  sensor: temp1
+node_intr_total:
+- {}
+node_load1:
+- {}
+node_load15:
+- {}
+node_load5:
+- {}
+node_memory_Active_anon_bytes:
+- {}
+node_memory_Active_bytes:
+- {}
+node_memory_Active_file_bytes:
+- {}
+node_memory_AnonHugePages_bytes:
+- {}
+node_memory_AnonPages_bytes:
+- {}
+node_memory_Bounce_bytes:
+- {}
+node_memory_Buffers_bytes:
+- {}
+node_memory_Cached_bytes:
+- {}
+node_memory_CommitLimit_bytes:
+- {}
+node_memory_Committed_AS_bytes:
+- {}
+node_memory_DirectMap1G_bytes:
+- {}
+node_memory_DirectMap2M_bytes:
+- {}
+node_memory_DirectMap4k_bytes:
+- {}
+node_memory_Dirty_bytes:
+- {}
+node_memory_FileHugePages_bytes:
+- {}
+node_memory_FilePmdMapped_bytes:
+- {}
+node_memory_HardwareCorrupted_bytes:
+- {}
+node_memory_HugePages_Free:
+- {}
+node_memory_HugePages_Rsvd:
+- {}
+node_memory_HugePages_Surp:
+- {}
+node_memory_HugePages_Total:
+- {}
+node_memory_Hugepagesize_bytes:
+- {}
+node_memory_Hugetlb_bytes:
+- {}
+node_memory_Inactive_anon_bytes:
+- {}
+node_memory_Inactive_bytes:
+- {}
+node_memory_Inactive_file_bytes:
+- {}
+node_memory_KReclaimable_bytes:
+- {}
+node_memory_KernelStack_bytes:
+- {}
+node_memory_Mapped_bytes:
+- {}
+node_memory_MemAvailable_bytes:
+- {}
+node_memory_MemFree_bytes:
+- {}
+node_memory_MemTotal_bytes:
+- {}
+node_memory_Mlocked_bytes:
+- {}
+node_memory_NFS_Unstable_bytes:
+- {}
+node_memory_PageTables_bytes:
+- {}
+node_memory_Percpu_bytes:
+- {}
+node_memory_SReclaimable_bytes:
+- {}
+node_memory_SUnreclaim_bytes:
+- {}
+node_memory_ShmemHugePages_bytes:
+- {}
+node_memory_ShmemPmdMapped_bytes:
+- {}
+node_memory_Shmem_bytes:
+- {}
+node_memory_Slab_bytes:
+- {}
+node_memory_SwapCached_bytes:
+- {}
+node_memory_SwapFree_bytes:
+- {}
+node_memory_SwapTotal_bytes:
+- {}
+node_memory_Unevictable_bytes:
+- {}
+node_memory_VmallocChunk_bytes:
+- {}
+node_memory_VmallocTotal_bytes:
+- {}
+node_memory_VmallocUsed_bytes:
+- {}
+node_memory_WritebackTmp_bytes:
+- {}
+node_memory_Writeback_bytes:
+- {}
+node_netstat_Icmp6_InErrors:
+- {}
+node_netstat_Icmp6_InMsgs:
+- {}
+node_netstat_Icmp6_OutMsgs:
+- {}
+node_netstat_Icmp_InErrors:
+- {}
+node_netstat_Icmp_InMsgs:
+- {}
+node_netstat_Icmp_OutMsgs:
+- {}
+node_netstat_Ip6_InOctets:
+- {}
+node_netstat_Ip6_OutOctets:
+- {}
+node_netstat_IpExt_InOctets:
+- {}
+node_netstat_IpExt_OutOctets:
+- {}
+node_netstat_Ip_Forwarding:
+- {}
+node_netstat_TcpExt_ListenDrops:
+- {}
+node_netstat_TcpExt_ListenOverflows:
+- {}
+node_netstat_TcpExt_SyncookiesFailed:
+- {}
+node_netstat_TcpExt_SyncookiesRecv:
+- {}
+node_netstat_TcpExt_SyncookiesSent:
+- {}
+node_netstat_TcpExt_TCPSynRetrans:
+- {}
+node_netstat_TcpExt_TCPTimeouts:
+- {}
+node_netstat_Tcp_ActiveOpens:
+- {}
+node_netstat_Tcp_CurrEstab:
+- {}
+node_netstat_Tcp_InErrs:
+- {}
+node_netstat_Tcp_InSegs:
+- {}
+node_netstat_Tcp_OutRsts:
+- {}
+node_netstat_Tcp_OutSegs:
+- {}
+node_netstat_Tcp_PassiveOpens:
+- {}
+node_netstat_Tcp_RetransSegs:
+- {}
+node_netstat_Udp6_InDatagrams:
+- {}
+node_netstat_Udp6_InErrors:
+- {}
+node_netstat_Udp6_NoPorts:
+- {}
+node_netstat_Udp6_OutDatagrams:
+- {}
+node_netstat_Udp6_RcvbufErrors:
+- {}
+node_netstat_Udp6_SndbufErrors:
+- {}
+node_netstat_UdpLite6_InErrors:
+- {}
+node_netstat_UdpLite_InErrors:
+- {}
+node_netstat_Udp_InDatagrams:
+- {}
+node_netstat_Udp_InErrors:
+- {}
+node_netstat_Udp_NoPorts:
+- {}
+node_netstat_Udp_OutDatagrams:
+- {}
+node_netstat_Udp_RcvbufErrors:
+- {}
+node_netstat_Udp_SndbufErrors:
+- {}
+node_network_address_assign_type:
+- device: br-695db5fee422
+- device: veth18308ac
+- device: lo
+- device: enp2s0
+- device: tailscale0
+- device: docker0
+- device: vethc0b1c2d
+- device: wlp3s0
+- device: veth2b738d7
+- device: veth70bbe68
+node_network_carrier:
+- device: br-695db5fee422
+- device: veth18308ac
+- device: lo
+- device: enp2s0
+- device: tailscale0
+- device: docker0
+- device: vethc0b1c2d
+- device: veth2b738d7
+- device: veth70bbe68
+node_network_carrier_changes_total:
+- device: br-695db5fee422
+- device: veth18308ac
+- device: lo
+- device: enp2s0
+- device: tailscale0
+- device: docker0
+- device: vethc0b1c2d
+- device: wlp3s0
+- device: veth2b738d7
+- device: veth70bbe68
+node_network_carrier_down_changes_total:
+- device: br-695db5fee422
+- device: veth18308ac
+- device: lo
+- device: enp2s0
+- device: tailscale0
+- device: docker0
+- device: vethc0b1c2d
+- device: wlp3s0
+- device: veth2b738d7
+- device: veth70bbe68
+node_network_carrier_up_changes_total:
+- device: br-695db5fee422
+- device: veth18308ac
+- device: lo
+- device: enp2s0
+- device: tailscale0
+- device: docker0
+- device: vethc0b1c2d
+- device: wlp3s0
+- device: veth2b738d7
+- device: veth70bbe68
+node_network_device_id:
+- device: br-695db5fee422
+- device: veth18308ac
+- device: lo
+- device: enp2s0
+- device: tailscale0
+- device: docker0
+- device: vethc0b1c2d
+- device: wlp3s0
+- device: veth2b738d7
+- device: veth70bbe68
+node_network_dormant:
+- device: br-695db5fee422
+- device: veth18308ac
+- device: lo
+- device: enp2s0
+- device: tailscale0
+- device: docker0
+- device: vethc0b1c2d
+- device: veth2b738d7
+- device: veth70bbe68
+node_network_flags:
+- device: br-695db5fee422
+- device: veth18308ac
+- device: lo
+- device: enp2s0
+- device: tailscale0
+- device: docker0
+- device: vethc0b1c2d
+- device: wlp3s0
+- device: veth2b738d7
+- device: veth70bbe68
+node_network_iface_id:
+- device: br-695db5fee422
+- device: veth18308ac
+- device: lo
+- device: enp2s0
+- device: tailscale0
+- device: docker0
+- device: vethc0b1c2d
+- device: wlp3s0
+- device: veth2b738d7
+- device: veth70bbe68
+node_network_iface_link:
+- device: br-695db5fee422
+- device: veth18308ac
+- device: lo
+- device: enp2s0
+- device: tailscale0
+- device: docker0
+- device: vethc0b1c2d
+- device: wlp3s0
+- device: veth2b738d7
+- device: veth70bbe68
+node_network_iface_link_mode:
+- device: br-695db5fee422
+- device: veth18308ac
+- device: lo
+- device: enp2s0
+- device: tailscale0
+- device: docker0
+- device: vethc0b1c2d
+- device: wlp3s0
+- device: veth2b738d7
+- device: veth70bbe68
+node_network_info:
+- address: a2:b6:c8:98:40:6d
+  adminstate: up
+  broadcast: ff:ff:ff:ff:ff:ff
+  device: vethc0b1c2d
+  duplex: full
+  ifalias: ''
+  operstate: up
+- address: ''
+  adminstate: up
+  broadcast: ''
+  device: tailscale0
+  duplex: full
+  ifalias: ''
+  operstate: unknown
+- address: b2:54:73:07:af:d0
+  adminstate: up
+  broadcast: ff:ff:ff:ff:ff:ff
+  device: docker0
+  duplex: unknown
+  ifalias: ''
+  operstate: up
+- address: 84:47:09:20:60:ac
+  adminstate: up
+  broadcast: ff:ff:ff:ff:ff:ff
+  device: enp2s0
+  duplex: full
+  ifalias: ''
+  operstate: up
+- address: 56:d8:cf:52:22:b3
+  adminstate: up
+  broadcast: ff:ff:ff:ff:ff:ff
+  device: veth2b738d7
+  duplex: full
+  ifalias: ''
+  operstate: up
+- address: fa:7c:be:d2:7b:fa
+  adminstate: up
+  broadcast: ff:ff:ff:ff:ff:ff
+  device: veth70bbe68
+  duplex: full
+  ifalias: ''
+  operstate: up
+- address: 00:00:00:00:00:00
+  adminstate: up
+  broadcast: 00:00:00:00:00:00
+  device: lo
+  duplex: ''
+  ifalias: ''
+  operstate: unknown
+- address: 0c:91:92:27:7b:3a
+  adminstate: down
+  broadcast: ff:ff:ff:ff:ff:ff
+  device: wlp3s0
+  duplex: ''
+  ifalias: ''
+  operstate: down
+- address: 56:53:c0:94:f2:b2
+  adminstate: up
+  broadcast: ff:ff:ff:ff:ff:ff
+  device: veth18308ac
+  duplex: full
+  ifalias: ''
+  operstate: up
+- address: 96:a9:d3:2e:18:02
+  adminstate: up
+  broadcast: ff:ff:ff:ff:ff:ff
+  device: br-695db5fee422
+  duplex: unknown
+  ifalias: ''
+  operstate: up
+node_network_mtu_bytes:
+- device: br-695db5fee422
+- device: veth18308ac
+- device: lo
+- device: enp2s0
+- device: tailscale0
+- device: docker0
+- device: vethc0b1c2d
+- device: wlp3s0
+- device: veth2b738d7
+- device: veth70bbe68
+node_network_name_assign_type:
+- device: br-695db5fee422
+- device: veth18308ac
+- device: lo
+- device: enp2s0
+- device: docker0
+- device: vethc0b1c2d
+- device: wlp3s0
+- device: veth2b738d7
+- device: veth70bbe68
+node_network_net_dev_group:
+- device: br-695db5fee422
+- device: veth18308ac
+- device: lo
+- device: enp2s0
+- device: tailscale0
+- device: docker0
+- device: vethc0b1c2d
+- device: wlp3s0
+- device: veth2b738d7
+- device: veth70bbe68
+node_network_protocol_type:
+- device: br-695db5fee422
+- device: veth18308ac
+- device: lo
+- device: enp2s0
+- device: tailscale0
+- device: docker0
+- device: vethc0b1c2d
+- device: wlp3s0
+- device: veth2b738d7
+- device: veth70bbe68
+node_network_receive_bytes_total:
+- device: br-695db5fee422
+- device: veth18308ac
+- device: lo
+- device: enp2s0
+- device: tailscale0
+- device: docker0
+- device: vethc0b1c2d
+- device: wlp3s0
+- device: veth2b738d7
+- device: veth70bbe68
+node_network_receive_compressed_total:
+- device: br-695db5fee422
+- device: veth18308ac
+- device: lo
+- device: enp2s0
+- device: tailscale0
+- device: docker0
+- device: vethc0b1c2d
+- device: wlp3s0
+- device: veth2b738d7
+- device: veth70bbe68
+node_network_receive_drop_total:
+- device: br-695db5fee422
+- device: veth18308ac
+- device: lo
+- device: enp2s0
+- device: tailscale0
+- device: docker0
+- device: vethc0b1c2d
+- device: wlp3s0
+- device: veth2b738d7
+- device: veth70bbe68
+node_network_receive_errs_total:
+- device: br-695db5fee422
+- device: veth18308ac
+- device: lo
+- device: enp2s0
+- device: tailscale0
+- device: docker0
+- device: vethc0b1c2d
+- device: wlp3s0
+- device: veth2b738d7
+- device: veth70bbe68
+node_network_receive_fifo_total:
+- device: br-695db5fee422
+- device: veth18308ac
+- device: lo
+- device: enp2s0
+- device: tailscale0
+- device: docker0
+- device: vethc0b1c2d
+- device: wlp3s0
+- device: veth2b738d7
+- device: veth70bbe68
+node_network_receive_frame_total:
+- device: br-695db5fee422
+- device: veth18308ac
+- device: lo
+- device: enp2s0
+- device: tailscale0
+- device: docker0
+- device: vethc0b1c2d
+- device: wlp3s0
+- device: veth2b738d7
+- device: veth70bbe68
+node_network_receive_multicast_total:
+- device: br-695db5fee422
+- device: veth18308ac
+- device: lo
+- device: enp2s0
+- device: tailscale0
+- device: docker0
+- device: vethc0b1c2d
+- device: wlp3s0
+- device: veth2b738d7
+- device: veth70bbe68
+node_network_receive_nohandler_total:
+- device: br-695db5fee422
+- device: veth18308ac
+- device: lo
+- device: enp2s0
+- device: tailscale0
+- device: docker0
+- device: vethc0b1c2d
+- device: wlp3s0
+- device: veth2b738d7
+- device: veth70bbe68
+node_network_receive_packets_total:
+- device: br-695db5fee422
+- device: veth18308ac
+- device: lo
+- device: enp2s0
+- device: tailscale0
+- device: docker0
+- device: vethc0b1c2d
+- device: wlp3s0
+- device: veth2b738d7
+- device: veth70bbe68
+node_network_speed_bytes:
+- device: br-695db5fee422
+- device: veth18308ac
+- device: enp2s0
+- device: tailscale0
+- device: docker0
+- device: vethc0b1c2d
+- device: veth2b738d7
+- device: veth70bbe68
+node_network_transmit_bytes_total:
+- device: br-695db5fee422
+- device: veth18308ac
+- device: lo
+- device: enp2s0
+- device: tailscale0
+- device: docker0
+- device: vethc0b1c2d
+- device: wlp3s0
+- device: veth2b738d7
+- device: veth70bbe68
+node_network_transmit_carrier_total:
+- device: br-695db5fee422
+- device: veth18308ac
+- device: lo
+- device: enp2s0
+- device: tailscale0
+- device: docker0
+- device: vethc0b1c2d
+- device: wlp3s0
+- device: veth2b738d7
+- device: veth70bbe68
+node_network_transmit_colls_total:
+- device: br-695db5fee422
+- device: veth18308ac
+- device: lo
+- device: enp2s0
+- device: tailscale0
+- device: docker0
+- device: vethc0b1c2d
+- device: wlp3s0
+- device: veth2b738d7
+- device: veth70bbe68
+node_network_transmit_compressed_total:
+- device: br-695db5fee422
+- device: veth18308ac
+- device: lo
+- device: enp2s0
+- device: tailscale0
+- device: docker0
+- device: vethc0b1c2d
+- device: wlp3s0
+- device: veth2b738d7
+- device: veth70bbe68
+node_network_transmit_drop_total:
+- device: br-695db5fee422
+- device: veth18308ac
+- device: lo
+- device: enp2s0
+- device: tailscale0
+- device: docker0
+- device: vethc0b1c2d
+- device: wlp3s0
+- device: veth2b738d7
+- device: veth70bbe68
+node_network_transmit_errs_total:
+- device: br-695db5fee422
+- device: veth18308ac
+- device: lo
+- device: enp2s0
+- device: tailscale0
+- device: docker0
+- device: vethc0b1c2d
+- device: wlp3s0
+- device: veth2b738d7
+- device: veth70bbe68
+node_network_transmit_fifo_total:
+- device: br-695db5fee422
+- device: veth18308ac
+- device: lo
+- device: enp2s0
+- device: tailscale0
+- device: docker0
+- device: vethc0b1c2d
+- device: wlp3s0
+- device: veth2b738d7
+- device: veth70bbe68
+node_network_transmit_packets_total:
+- device: br-695db5fee422
+- device: veth18308ac
+- device: lo
+- device: enp2s0
+- device: tailscale0
+- device: docker0
+- device: vethc0b1c2d
+- device: wlp3s0
+- device: veth2b738d7
+- device: veth70bbe68
+node_network_transmit_queue_length:
+- device: br-695db5fee422
+- device: veth18308ac
+- device: lo
+- device: enp2s0
+- device: tailscale0
+- device: docker0
+- device: vethc0b1c2d
+- device: wlp3s0
+- device: veth2b738d7
+- device: veth70bbe68
+node_network_up:
+- device: br-695db5fee422
+- device: veth18308ac
+- device: lo
+- device: enp2s0
+- device: tailscale0
+- device: docker0
+- device: vethc0b1c2d
+- device: wlp3s0
+- device: veth2b738d7
+- device: veth70bbe68
+node_nf_conntrack_entries:
+- {}
+node_nf_conntrack_entries_limit:
+- {}
+node_nvme_info:
+- device: nvme0
+  firmware_revision: ZTA32JF0
+  model: ZHITAI TiPro7000 1TB
+  serial: ZTA21T0KA2329305FA
+  state: live
+node_os_info:
+- build_id: ''
+  id: ubuntu
+  id_like: debian
+  image_id: ''
+  image_version: ''
+  name: Ubuntu
+  pretty_name: Ubuntu 22.04.5 LTS
+  variant: ''
+  variant_id: ''
+  version: 22.04.5 LTS (Jammy Jellyfish)
+  version_codename: jammy
+  version_id: '22.04'
+node_os_version:
+- id: ubuntu
+  id_like: debian
+  name: Ubuntu
+node_pressure_cpu_waiting_seconds_total:
+- {}
+node_pressure_io_stalled_seconds_total:
+- {}
+node_pressure_io_waiting_seconds_total:
+- {}
+node_pressure_memory_stalled_seconds_total:
+- {}
+node_pressure_memory_waiting_seconds_total:
+- {}
+node_procs_blocked:
+- {}
+node_procs_running:
+- {}
+node_schedstat_running_seconds_total:
+- cpu: '4'
+- cpu: '8'
+- cpu: '11'
+- cpu: '1'
+- cpu: '2'
+- cpu: '13'
+- cpu: '12'
+- cpu: '15'
+- cpu: '6'
+- cpu: '9'
+- cpu: '14'
+- cpu: '0'
+- cpu: '10'
+- cpu: '5'
+- cpu: '3'
+- cpu: '7'
+node_schedstat_timeslices_total:
+- cpu: '4'
+- cpu: '8'
+- cpu: '11'
+- cpu: '1'
+- cpu: '2'
+- cpu: '13'
+- cpu: '12'
+- cpu: '15'
+- cpu: '6'
+- cpu: '9'
+- cpu: '14'
+- cpu: '0'
+- cpu: '10'
+- cpu: '5'
+- cpu: '3'
+- cpu: '7'
+node_schedstat_waiting_seconds_total:
+- cpu: '4'
+- cpu: '8'
+- cpu: '11'
+- cpu: '1'
+- cpu: '2'
+- cpu: '13'
+- cpu: '12'
+- cpu: '15'
+- cpu: '6'
+- cpu: '9'
+- cpu: '14'
+- cpu: '0'
+- cpu: '10'
+- cpu: '5'
+- cpu: '3'
+- cpu: '7'
+node_scrape_collector_duration_seconds:
+- collector: fibrechannel
+- collector: sockstat
+- collector: filefd
+- collector: netstat
+- collector: loadavg
+- collector: softnet
+- collector: cpufreq
+- collector: cpu
+- collector: hwmon
+- collector: stat
+- collector: pressure
+- collector: meminfo
+- collector: uname
+- collector: schedstat
+- collector: zfs
+- collector: arp
+- collector: infiniband
+- collector: nfsd
+- collector: timex
+- collector: xfs
+- collector: mdadm
+- collector: os
+- collector: textfile
+- collector: rapl
+- collector: tapestats
+- collector: nfs
+- collector: time
+- collector: ipvs
+- collector: powersupplyclass
+- collector: filesystem
+- collector: udp_queues
+- collector: netclass
+- collector: selinux
+- collector: edac
+- collector: netdev
+- collector: bonding
+- collector: conntrack
+- collector: entropy
+- collector: btrfs
+- collector: bcache
+- collector: diskstats
+- collector: dmi
+- collector: thermal_zone
+- collector: nvme
+- collector: vmstat
+node_scrape_collector_success:
+- collector: fibrechannel
+- collector: sockstat
+- collector: filefd
+- collector: netstat
+- collector: loadavg
+- collector: softnet
+- collector: cpufreq
+- collector: cpu
+- collector: hwmon
+- collector: stat
+- collector: pressure
+- collector: meminfo
+- collector: uname
+- collector: schedstat
+- collector: zfs
+- collector: arp
+- collector: infiniband
+- collector: nfsd
+- collector: timex
+- collector: xfs
+- collector: mdadm
+- collector: os
+- collector: textfile
+- collector: rapl
+- collector: tapestats
+- collector: nfs
+- collector: time
+- collector: ipvs
+- collector: powersupplyclass
+- collector: filesystem
+- collector: udp_queues
+- collector: netclass
+- collector: selinux
+- collector: edac
+- collector: netdev
+- collector: bonding
+- collector: conntrack
+- collector: entropy
+- collector: btrfs
+- collector: bcache
+- collector: diskstats
+- collector: dmi
+- collector: thermal_zone
+- collector: nvme
+- collector: vmstat
+node_selinux_enabled:
+- {}
+node_sockstat_FRAG6_inuse:
+- {}
+node_sockstat_FRAG6_memory:
+- {}
+node_sockstat_FRAG_inuse:
+- {}
+node_sockstat_FRAG_memory:
+- {}
+node_sockstat_RAW6_inuse:
+- {}
+node_sockstat_RAW_inuse:
+- {}
+node_sockstat_TCP6_inuse:
+- {}
+node_sockstat_TCP_alloc:
+- {}
+node_sockstat_TCP_inuse:
+- {}
+node_sockstat_TCP_mem:
+- {}
+node_sockstat_TCP_mem_bytes:
+- {}
+node_sockstat_TCP_orphan:
+- {}
+node_sockstat_TCP_tw:
+- {}
+node_sockstat_UDP6_inuse:
+- {}
+node_sockstat_UDPLITE6_inuse:
+- {}
+node_sockstat_UDPLITE_inuse:
+- {}
+node_sockstat_UDP_inuse:
+- {}
+node_sockstat_UDP_mem:
+- {}
+node_sockstat_UDP_mem_bytes:
+- {}
+node_sockstat_sockets_used:
+- {}
+node_softnet_backlog_len:
+- cpu: '4'
+- cpu: '8'
+- cpu: '11'
+- cpu: '1'
+- cpu: '2'
+- cpu: '13'
+- cpu: '12'
+- cpu: '15'
+- cpu: '6'
+- cpu: '9'
+- cpu: '14'
+- cpu: '0'
+- cpu: '10'
+- cpu: '5'
+- cpu: '3'
+- cpu: '7'
+node_softnet_cpu_collision_total:
+- cpu: '4'
+- cpu: '8'
+- cpu: '11'
+- cpu: '1'
+- cpu: '2'
+- cpu: '13'
+- cpu: '12'
+- cpu: '15'
+- cpu: '6'
+- cpu: '9'
+- cpu: '14'
+- cpu: '0'
+- cpu: '10'
+- cpu: '5'
+- cpu: '3'
+- cpu: '7'
+node_softnet_dropped_total:
+- cpu: '4'
+- cpu: '8'
+- cpu: '11'
+- cpu: '1'
+- cpu: '2'
+- cpu: '13'
+- cpu: '12'
+- cpu: '15'
+- cpu: '6'
+- cpu: '9'
+- cpu: '14'
+- cpu: '0'
+- cpu: '10'
+- cpu: '5'
+- cpu: '3'
+- cpu: '7'
+node_softnet_flow_limit_count_total:
+- cpu: '4'
+- cpu: '8'
+- cpu: '11'
+- cpu: '1'
+- cpu: '2'
+- cpu: '13'
+- cpu: '12'
+- cpu: '15'
+- cpu: '6'
+- cpu: '9'
+- cpu: '14'
+- cpu: '0'
+- cpu: '10'
+- cpu: '5'
+- cpu: '3'
+- cpu: '7'
+node_softnet_processed_total:
+- cpu: '4'
+- cpu: '8'
+- cpu: '11'
+- cpu: '1'
+- cpu: '2'
+- cpu: '13'
+- cpu: '12'
+- cpu: '15'
+- cpu: '6'
+- cpu: '9'
+- cpu: '14'
+- cpu: '0'
+- cpu: '10'
+- cpu: '5'
+- cpu: '3'
+- cpu: '7'
+node_softnet_received_rps_total:
+- cpu: '4'
+- cpu: '8'
+- cpu: '11'
+- cpu: '1'
+- cpu: '2'
+- cpu: '13'
+- cpu: '12'
+- cpu: '15'
+- cpu: '6'
+- cpu: '9'
+- cpu: '14'
+- cpu: '0'
+- cpu: '10'
+- cpu: '5'
+- cpu: '3'
+- cpu: '7'
+node_softnet_times_squeezed_total:
+- cpu: '4'
+- cpu: '8'
+- cpu: '11'
+- cpu: '1'
+- cpu: '2'
+- cpu: '13'
+- cpu: '12'
+- cpu: '15'
+- cpu: '6'
+- cpu: '9'
+- cpu: '14'
+- cpu: '0'
+- cpu: '10'
+- cpu: '5'
+- cpu: '3'
+- cpu: '7'
+node_textfile_scrape_error:
+- {}
+node_thermal_zone_temp:
+- type: acpitz
+  zone: '0'
+node_time_clocksource_available_info:
+- clocksource: tsc
+  device: '0'
+- clocksource: acpi_pm
+  device: '0'
+node_time_clocksource_current_info:
+- clocksource: tsc
+  device: '0'
+node_time_seconds:
+- {}
+node_time_zone_offset_seconds:
+- time_zone: UTC
+node_timex_estimated_error_seconds:
+- {}
+node_timex_frequency_adjustment_ratio:
+- {}
+node_timex_loop_time_constant:
+- {}
+node_timex_maxerror_seconds:
+- {}
+node_timex_offset_seconds:
+- {}
+node_timex_pps_calibration_total:
+- {}
+node_timex_pps_error_total:
+- {}
+node_timex_pps_frequency_hertz:
+- {}
+node_timex_pps_jitter_seconds:
+- {}
+node_timex_pps_jitter_total:
+- {}
+node_timex_pps_shift_seconds:
+- {}
+node_timex_pps_stability_exceeded_total:
+- {}
+node_timex_pps_stability_hertz:
+- {}
+node_timex_status:
+- {}
+node_timex_sync_status:
+- {}
+node_timex_tai_offset_seconds:
+- {}
+node_timex_tick_seconds:
+- {}
+node_udp_queues:
+- ip: v6
+  queue: rx
+- ip: v4
+  queue: rx
+- ip: v6
+  queue: tx
+- ip: v4
+  queue: tx
+node_uname_info:
+- domainname: (none)
+  machine: x86_64
+  nodename: minipc-0
+  release: 5.15.0-134-generic
+  sysname: Linux
+  version: '#145-Ubuntu SMP Wed Feb 12 20:08:39 UTC 2025'
+node_vmstat_oom_kill:
+- {}
+node_vmstat_pgfault:
+- {}
+node_vmstat_pgmajfault:
+- {}
+node_vmstat_pgpgin:
+- {}
+node_vmstat_pgpgout:
+- {}
+node_vmstat_pswpin:
+- {}
+node_vmstat_pswpout:
+- {}
+process_cpu_seconds_total:
+- {}
+process_max_fds:
+- {}
+process_open_fds:
+- {}
+process_resident_memory_bytes:
+- {}
+process_start_time_seconds:
+- {}
+process_virtual_memory_bytes:
+- {}
+process_virtual_memory_max_bytes:
+- {}
+promhttp_metric_handler_errors_total:
+- cause: encoding
+- cause: gathering
+promhttp_metric_handler_requests_in_flight:
+- {}
+promhttp_metric_handler_requests_total:
+- code: '500'
+- code: '200'
+- code: '503'
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
   "protobuf==5.29.4",
   "python-snappy>=0.7.3",
   "pyyaml",
+  "requests>=2.32.3",
   "tqdm",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,0 @@
-argparse
-csv
-pyyaml
-tqdm

--- a/uv.lock
+++ b/uv.lock
@@ -7,6 +7,76 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "certifi"
+version = "2025.1.31"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1c/ab/c9f1e32b7b1bf505bf26f0ef697775960db7932abeb7b516de930ba2705f/certifi-2025.1.31.tar.gz", hash = "sha256:3d5da6925056f6f18f119200434a4780a94263f10d1c21d032a6f6b2baa20651", size = 167577 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/fc/bce832fd4fd99766c04d1ee0eead6b0ec6486fb100ae5e74c1d91292b982/certifi-2025.1.31-py3-none-any.whl", hash = "sha256:ca78db4565a652026a4db2bcdf68f2fb589ea80d0be70e03929ed730746b84fe", size = 166393 },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/16/b0/572805e227f01586461c80e0fd25d65a2115599cc9dad142fee4b747c357/charset_normalizer-3.4.1.tar.gz", hash = "sha256:44251f18cd68a75b56585dd00dae26183e102cd5e0f9f1466e6df5da2ed64ea3", size = 123188 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/58/5580c1716040bc89206c77d8f74418caf82ce519aae06450393ca73475d1/charset_normalizer-3.4.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:91b36a978b5ae0ee86c394f5a54d6ef44db1de0815eb43de826d41d21e4af3de", size = 198013 },
+    { url = "https://files.pythonhosted.org/packages/d0/11/00341177ae71c6f5159a08168bcb98c6e6d196d372c94511f9f6c9afe0c6/charset_normalizer-3.4.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7461baadb4dc00fd9e0acbe254e3d7d2112e7f92ced2adc96e54ef6501c5f176", size = 141285 },
+    { url = "https://files.pythonhosted.org/packages/01/09/11d684ea5819e5a8f5100fb0b38cf8d02b514746607934134d31233e02c8/charset_normalizer-3.4.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e218488cd232553829be0664c2292d3af2eeeb94b32bea483cf79ac6a694e037", size = 151449 },
+    { url = "https://files.pythonhosted.org/packages/08/06/9f5a12939db324d905dc1f70591ae7d7898d030d7662f0d426e2286f68c9/charset_normalizer-3.4.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:80ed5e856eb7f30115aaf94e4a08114ccc8813e6ed1b5efa74f9f82e8509858f", size = 143892 },
+    { url = "https://files.pythonhosted.org/packages/93/62/5e89cdfe04584cb7f4d36003ffa2936681b03ecc0754f8e969c2becb7e24/charset_normalizer-3.4.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b010a7a4fd316c3c484d482922d13044979e78d1861f0e0650423144c616a46a", size = 146123 },
+    { url = "https://files.pythonhosted.org/packages/a9/ac/ab729a15c516da2ab70a05f8722ecfccc3f04ed7a18e45c75bbbaa347d61/charset_normalizer-3.4.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4532bff1b8421fd0a320463030c7520f56a79c9024a4e88f01c537316019005a", size = 147943 },
+    { url = "https://files.pythonhosted.org/packages/03/d2/3f392f23f042615689456e9a274640c1d2e5dd1d52de36ab8f7955f8f050/charset_normalizer-3.4.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:d973f03c0cb71c5ed99037b870f2be986c3c05e63622c017ea9816881d2dd247", size = 142063 },
+    { url = "https://files.pythonhosted.org/packages/f2/e3/e20aae5e1039a2cd9b08d9205f52142329f887f8cf70da3650326670bddf/charset_normalizer-3.4.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:3a3bd0dcd373514dcec91c411ddb9632c0d7d92aed7093b8c3bbb6d69ca74408", size = 150578 },
+    { url = "https://files.pythonhosted.org/packages/8d/af/779ad72a4da0aed925e1139d458adc486e61076d7ecdcc09e610ea8678db/charset_normalizer-3.4.1-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:d9c3cdf5390dcd29aa8056d13e8e99526cda0305acc038b96b30352aff5ff2bb", size = 153629 },
+    { url = "https://files.pythonhosted.org/packages/c2/b6/7aa450b278e7aa92cf7732140bfd8be21f5f29d5bf334ae987c945276639/charset_normalizer-3.4.1-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:2bdfe3ac2e1bbe5b59a1a63721eb3b95fc9b6817ae4a46debbb4e11f6232428d", size = 150778 },
+    { url = "https://files.pythonhosted.org/packages/39/f4/d9f4f712d0951dcbfd42920d3db81b00dd23b6ab520419626f4023334056/charset_normalizer-3.4.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:eab677309cdb30d047996b36d34caeda1dc91149e4fdca0b1a039b3f79d9a807", size = 146453 },
+    { url = "https://files.pythonhosted.org/packages/49/2b/999d0314e4ee0cff3cb83e6bc9aeddd397eeed693edb4facb901eb8fbb69/charset_normalizer-3.4.1-cp310-cp310-win32.whl", hash = "sha256:c0429126cf75e16c4f0ad00ee0eae4242dc652290f940152ca8c75c3a4b6ee8f", size = 95479 },
+    { url = "https://files.pythonhosted.org/packages/2d/ce/3cbed41cff67e455a386fb5e5dd8906cdda2ed92fbc6297921f2e4419309/charset_normalizer-3.4.1-cp310-cp310-win_amd64.whl", hash = "sha256:9f0b8b1c6d84c8034a44893aba5e767bf9c7a211e313a9605d9c617d7083829f", size = 102790 },
+    { url = "https://files.pythonhosted.org/packages/72/80/41ef5d5a7935d2d3a773e3eaebf0a9350542f2cab4eac59a7a4741fbbbbe/charset_normalizer-3.4.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:8bfa33f4f2672964266e940dd22a195989ba31669bd84629f05fab3ef4e2d125", size = 194995 },
+    { url = "https://files.pythonhosted.org/packages/7a/28/0b9fefa7b8b080ec492110af6d88aa3dea91c464b17d53474b6e9ba5d2c5/charset_normalizer-3.4.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:28bf57629c75e810b6ae989f03c0828d64d6b26a5e205535585f96093e405ed1", size = 139471 },
+    { url = "https://files.pythonhosted.org/packages/71/64/d24ab1a997efb06402e3fc07317e94da358e2585165930d9d59ad45fcae2/charset_normalizer-3.4.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f08ff5e948271dc7e18a35641d2f11a4cd8dfd5634f55228b691e62b37125eb3", size = 149831 },
+    { url = "https://files.pythonhosted.org/packages/37/ed/be39e5258e198655240db5e19e0b11379163ad7070962d6b0c87ed2c4d39/charset_normalizer-3.4.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:234ac59ea147c59ee4da87a0c0f098e9c8d169f4dc2a159ef720f1a61bbe27cd", size = 142335 },
+    { url = "https://files.pythonhosted.org/packages/88/83/489e9504711fa05d8dde1574996408026bdbdbd938f23be67deebb5eca92/charset_normalizer-3.4.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fd4ec41f914fa74ad1b8304bbc634b3de73d2a0889bd32076342a573e0779e00", size = 143862 },
+    { url = "https://files.pythonhosted.org/packages/c6/c7/32da20821cf387b759ad24627a9aca289d2822de929b8a41b6241767b461/charset_normalizer-3.4.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:eea6ee1db730b3483adf394ea72f808b6e18cf3cb6454b4d86e04fa8c4327a12", size = 145673 },
+    { url = "https://files.pythonhosted.org/packages/68/85/f4288e96039abdd5aeb5c546fa20a37b50da71b5cf01e75e87f16cd43304/charset_normalizer-3.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c96836c97b1238e9c9e3fe90844c947d5afbf4f4c92762679acfe19927d81d77", size = 140211 },
+    { url = "https://files.pythonhosted.org/packages/28/a3/a42e70d03cbdabc18997baf4f0227c73591a08041c149e710045c281f97b/charset_normalizer-3.4.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:4d86f7aff21ee58f26dcf5ae81a9addbd914115cdebcbb2217e4f0ed8982e146", size = 148039 },
+    { url = "https://files.pythonhosted.org/packages/85/e4/65699e8ab3014ecbe6f5c71d1a55d810fb716bbfd74f6283d5c2aa87febf/charset_normalizer-3.4.1-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:09b5e6733cbd160dcc09589227187e242a30a49ca5cefa5a7edd3f9d19ed53fd", size = 151939 },
+    { url = "https://files.pythonhosted.org/packages/b1/82/8e9fe624cc5374193de6860aba3ea8070f584c8565ee77c168ec13274bd2/charset_normalizer-3.4.1-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:5777ee0881f9499ed0f71cc82cf873d9a0ca8af166dfa0af8ec4e675b7df48e6", size = 149075 },
+    { url = "https://files.pythonhosted.org/packages/3d/7b/82865ba54c765560c8433f65e8acb9217cb839a9e32b42af4aa8e945870f/charset_normalizer-3.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:237bdbe6159cff53b4f24f397d43c6336c6b0b42affbe857970cefbb620911c8", size = 144340 },
+    { url = "https://files.pythonhosted.org/packages/b5/b6/9674a4b7d4d99a0d2df9b215da766ee682718f88055751e1e5e753c82db0/charset_normalizer-3.4.1-cp311-cp311-win32.whl", hash = "sha256:8417cb1f36cc0bc7eaba8ccb0e04d55f0ee52df06df3ad55259b9a323555fc8b", size = 95205 },
+    { url = "https://files.pythonhosted.org/packages/1e/ab/45b180e175de4402dcf7547e4fb617283bae54ce35c27930a6f35b6bef15/charset_normalizer-3.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:d7f50a1f8c450f3925cb367d011448c39239bb3eb4117c36a6d354794de4ce76", size = 102441 },
+    { url = "https://files.pythonhosted.org/packages/0a/9a/dd1e1cdceb841925b7798369a09279bd1cf183cef0f9ddf15a3a6502ee45/charset_normalizer-3.4.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:73d94b58ec7fecbc7366247d3b0b10a21681004153238750bb67bd9012414545", size = 196105 },
+    { url = "https://files.pythonhosted.org/packages/d3/8c/90bfabf8c4809ecb648f39794cf2a84ff2e7d2a6cf159fe68d9a26160467/charset_normalizer-3.4.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dad3e487649f498dd991eeb901125411559b22e8d7ab25d3aeb1af367df5efd7", size = 140404 },
+    { url = "https://files.pythonhosted.org/packages/ad/8f/e410d57c721945ea3b4f1a04b74f70ce8fa800d393d72899f0a40526401f/charset_normalizer-3.4.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c30197aa96e8eed02200a83fba2657b4c3acd0f0aa4bdc9f6c1af8e8962e0757", size = 150423 },
+    { url = "https://files.pythonhosted.org/packages/f0/b8/e6825e25deb691ff98cf5c9072ee0605dc2acfca98af70c2d1b1bc75190d/charset_normalizer-3.4.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2369eea1ee4a7610a860d88f268eb39b95cb588acd7235e02fd5a5601773d4fa", size = 143184 },
+    { url = "https://files.pythonhosted.org/packages/3e/a2/513f6cbe752421f16d969e32f3583762bfd583848b763913ddab8d9bfd4f/charset_normalizer-3.4.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc2722592d8998c870fa4e290c2eec2c1569b87fe58618e67d38b4665dfa680d", size = 145268 },
+    { url = "https://files.pythonhosted.org/packages/74/94/8a5277664f27c3c438546f3eb53b33f5b19568eb7424736bdc440a88a31f/charset_normalizer-3.4.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ffc9202a29ab3920fa812879e95a9e78b2465fd10be7fcbd042899695d75e616", size = 147601 },
+    { url = "https://files.pythonhosted.org/packages/7c/5f/6d352c51ee763623a98e31194823518e09bfa48be2a7e8383cf691bbb3d0/charset_normalizer-3.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:804a4d582ba6e5b747c625bf1255e6b1507465494a40a2130978bda7b932c90b", size = 141098 },
+    { url = "https://files.pythonhosted.org/packages/78/d4/f5704cb629ba5ab16d1d3d741396aec6dc3ca2b67757c45b0599bb010478/charset_normalizer-3.4.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:0f55e69f030f7163dffe9fd0752b32f070566451afe180f99dbeeb81f511ad8d", size = 149520 },
+    { url = "https://files.pythonhosted.org/packages/c5/96/64120b1d02b81785f222b976c0fb79a35875457fa9bb40827678e54d1bc8/charset_normalizer-3.4.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:c4c3e6da02df6fa1410a7680bd3f63d4f710232d3139089536310d027950696a", size = 152852 },
+    { url = "https://files.pythonhosted.org/packages/84/c9/98e3732278a99f47d487fd3468bc60b882920cef29d1fa6ca460a1fdf4e6/charset_normalizer-3.4.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:5df196eb874dae23dcfb968c83d4f8fdccb333330fe1fc278ac5ceeb101003a9", size = 150488 },
+    { url = "https://files.pythonhosted.org/packages/13/0e/9c8d4cb99c98c1007cc11eda969ebfe837bbbd0acdb4736d228ccaabcd22/charset_normalizer-3.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e358e64305fe12299a08e08978f51fc21fac060dcfcddd95453eabe5b93ed0e1", size = 146192 },
+    { url = "https://files.pythonhosted.org/packages/b2/21/2b6b5b860781a0b49427309cb8670785aa543fb2178de875b87b9cc97746/charset_normalizer-3.4.1-cp312-cp312-win32.whl", hash = "sha256:9b23ca7ef998bc739bf6ffc077c2116917eabcc901f88da1b9856b210ef63f35", size = 95550 },
+    { url = "https://files.pythonhosted.org/packages/21/5b/1b390b03b1d16c7e382b561c5329f83cc06623916aab983e8ab9239c7d5c/charset_normalizer-3.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:6ff8a4a60c227ad87030d76e99cd1698345d4491638dfa6673027c48b3cd395f", size = 102785 },
+    { url = "https://files.pythonhosted.org/packages/38/94/ce8e6f63d18049672c76d07d119304e1e2d7c6098f0841b51c666e9f44a0/charset_normalizer-3.4.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:aabfa34badd18f1da5ec1bc2715cadc8dca465868a4e73a0173466b688f29dda", size = 195698 },
+    { url = "https://files.pythonhosted.org/packages/24/2e/dfdd9770664aae179a96561cc6952ff08f9a8cd09a908f259a9dfa063568/charset_normalizer-3.4.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:22e14b5d70560b8dd51ec22863f370d1e595ac3d024cb8ad7d308b4cd95f8313", size = 140162 },
+    { url = "https://files.pythonhosted.org/packages/24/4e/f646b9093cff8fc86f2d60af2de4dc17c759de9d554f130b140ea4738ca6/charset_normalizer-3.4.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8436c508b408b82d87dc5f62496973a1805cd46727c34440b0d29d8a2f50a6c9", size = 150263 },
+    { url = "https://files.pythonhosted.org/packages/5e/67/2937f8d548c3ef6e2f9aab0f6e21001056f692d43282b165e7c56023e6dd/charset_normalizer-3.4.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2d074908e1aecee37a7635990b2c6d504cd4766c7bc9fc86d63f9c09af3fa11b", size = 142966 },
+    { url = "https://files.pythonhosted.org/packages/52/ed/b7f4f07de100bdb95c1756d3a4d17b90c1a3c53715c1a476f8738058e0fa/charset_normalizer-3.4.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:955f8851919303c92343d2f66165294848d57e9bba6cf6e3625485a70a038d11", size = 144992 },
+    { url = "https://files.pythonhosted.org/packages/96/2c/d49710a6dbcd3776265f4c923bb73ebe83933dfbaa841c5da850fe0fd20b/charset_normalizer-3.4.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:44ecbf16649486d4aebafeaa7ec4c9fed8b88101f4dd612dcaf65d5e815f837f", size = 147162 },
+    { url = "https://files.pythonhosted.org/packages/b4/41/35ff1f9a6bd380303dea55e44c4933b4cc3c4850988927d4082ada230273/charset_normalizer-3.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:0924e81d3d5e70f8126529951dac65c1010cdf117bb75eb02dd12339b57749dd", size = 140972 },
+    { url = "https://files.pythonhosted.org/packages/fb/43/c6a0b685fe6910d08ba971f62cd9c3e862a85770395ba5d9cad4fede33ab/charset_normalizer-3.4.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:2967f74ad52c3b98de4c3b32e1a44e32975e008a9cd2a8cc8966d6a5218c5cb2", size = 149095 },
+    { url = "https://files.pythonhosted.org/packages/4c/ff/a9a504662452e2d2878512115638966e75633519ec11f25fca3d2049a94a/charset_normalizer-3.4.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:c75cb2a3e389853835e84a2d8fb2b81a10645b503eca9bcb98df6b5a43eb8886", size = 152668 },
+    { url = "https://files.pythonhosted.org/packages/6c/71/189996b6d9a4b932564701628af5cee6716733e9165af1d5e1b285c530ed/charset_normalizer-3.4.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:09b26ae6b1abf0d27570633b2b078a2a20419c99d66fb2823173d73f188ce601", size = 150073 },
+    { url = "https://files.pythonhosted.org/packages/e4/93/946a86ce20790e11312c87c75ba68d5f6ad2208cfb52b2d6a2c32840d922/charset_normalizer-3.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:fa88b843d6e211393a37219e6a1c1df99d35e8fd90446f1118f4216e307e48cd", size = 145732 },
+    { url = "https://files.pythonhosted.org/packages/cd/e5/131d2fb1b0dddafc37be4f3a2fa79aa4c037368be9423061dccadfd90091/charset_normalizer-3.4.1-cp313-cp313-win32.whl", hash = "sha256:eb8178fe3dba6450a3e024e95ac49ed3400e506fd4e9e5c32d30adda88cbd407", size = 95391 },
+    { url = "https://files.pythonhosted.org/packages/27/f2/4f9a69cc7712b9b5ad8fdb87039fd89abba997ad5cbe690d1835d40405b0/charset_normalizer-3.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:b1ac5992a838106edb89654e0aebfc24f5848ae2547d22c2c3f66454daa11971", size = 102702 },
+    { url = "https://files.pythonhosted.org/packages/0e/f6/65ecc6878a89bb1c23a086ea335ad4bf21a588990c3f535a227b9eea9108/charset_normalizer-3.4.1-py3-none-any.whl", hash = "sha256:d98b1668f06378c6dbefec3b92299716b931cd4e6061f3c875a71ced1780ab85", size = 49767 },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -82,6 +152,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/26/f7/6422b9e4d148f1a351c0358a95d59023f25cab76609b180804f6a3ed17e9/cramjam-2.9.1-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fb01f6e38719818778144d3165a89ea1ad9dc58c6342b7f20aa194c70f34cbd1", size = 2119487 },
     { url = "https://files.pythonhosted.org/packages/b5/59/6fc930217f7ae085eca6d22d3477cd0145a105cdc39e63b834cb0c1b25e3/cramjam-2.9.1-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6b5cef5cf40725fe64592af9ec163e7389855077700678a1d94bec549403a74d", size = 2400910 },
     { url = "https://files.pythonhosted.org/packages/2d/36/7e53cf5aaed4b446490e298f7571e69ce15d0dfb148feabe8bf02e58827f/cramjam-2.9.1-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:ac48b978aa0675f62b642750e798c394a64d25ce852e4e541f69bef9a564c2f0", size = 2100860 },
+]
+
+[[package]]
+name = "idna"
+version = "3.10"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442 },
 ]
 
 [[package]]
@@ -177,6 +256,21 @@ wheels = [
 ]
 
 [[package]]
+name = "requests"
+version = "2.32.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/63/70/2bf7780ad2d390a8d301ad0b550f1581eadbd9a20f896afe06353c2a2913/requests-2.32.3.tar.gz", hash = "sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760", size = 131218 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/9b/335f9764261e915ed497fcdeb11df5dfd6f7bf257d4a6a2a686d80da4d54/requests-2.32.3-py3-none-any.whl", hash = "sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6", size = 64928 },
+]
+
+[[package]]
 name = "tqdm"
 version = "4.67.1"
 source = { registry = "https://pypi.org/simple" }
@@ -196,6 +290,7 @@ dependencies = [
     { name = "protobuf" },
     { name = "python-snappy" },
     { name = "pyyaml" },
+    { name = "requests" },
     { name = "tqdm" },
 ]
 
@@ -209,6 +304,7 @@ requires-dist = [
     { name = "protobuf", specifier = "==5.29.4" },
     { name = "python-snappy", specifier = ">=0.7.3" },
     { name = "pyyaml" },
+    { name = "requests", specifier = ">=2.32.3" },
     { name = "tqdm" },
 ]
 
@@ -222,4 +318,13 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/df/db/f35a00659bc03fec321ba8bce9420de607a1d37f8342eee1863174c69557/typing_extensions-4.12.2.tar.gz", hash = "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8", size = 85321 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d", size = 37438 },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/63/e53da845320b757bf29ef6a9062f5c669fe997973f966045cb019c3f4b66/urllib3-2.3.0.tar.gz", hash = "sha256:f8c5449b3cf0861679ce7e0503c7b44b5ec981bec0d1d3795a07f1ba96f0204d", size = 307268 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/19/4ec628951a74043532ca2cf5d97b7b14863931476d117c471e8e2b1eb39f/urllib3-2.3.0-py3-none-any.whl", hash = "sha256:1cee9ad369867bfdbbb48b7dd50374c0967a0bb7710050facf0dd6911440e3df", size = 128369 },
 ]


### PR DESCRIPTION
This patch updates how we generate time-series. We will use a few "base" time-series that generated from openmetrics format, ~~plus~~ multiplies tags we configure in `config.yaml` to generate full time-series and samples.

In next patch I will refactor this to separate steps of labels and samples.